### PR TITLE
Proposal: Rename queryString to parameters as queryString is misleading for an array

### DIFF
--- a/versions/2.0.0.md
+++ b/versions/2.0.0.md
@@ -13,7 +13,7 @@ Summary of HAR object types:
     - [timings](#timings)
     - [request](#request)
       - [headers](#headers)
-      - [queryString](#querystring)
+      - [parameters](#parameters)
       - [content](#content)
     - [response](#response)
       - [headers](#headers)
@@ -117,7 +117,7 @@ This object contains detailed info about performed request.
   "headersSize": 62,
   "bodyCaptured": true,
   "bodySize": 25,
-  "queryString" : [],
+  "parameters" : [],
   "headers": [],
   "content" : {}
 }
@@ -131,7 +131,7 @@ This object contains detailed info about performed request.
 | **headersSize**                 | `Number`  | ✔️        | `0`     | Total number of bytes from the start of the HTTP request message until (and including) the double `CRLF` before the body |
 | **bodyCaptured**                | `Boolean` | ✔️        | `false` | Indicates whether the request body info was captured                                                                     |
 | **bodySize**                    | `Number`  | ✔️        | `0`     | Size of the request body in bytes (e.g. `POST` payload)                                                                  |
-| [**queryString**](#querystring) | `Array`   | ✖        | `N/A`   | List of query parameter [objects](#querystring)                                                                          |
+| [**parameters**](#parameters)   | `Array`   | ✖        | `N/A`   | List of query parameter [objects](#parameters)                                                                          |
 | [**headers**](#headers)         | `Array`   | ✔️        | `N/A`   | List of [`header`](#headers) objects                                                                                     |
 | [**content**](#content)         | `Object`  | ✖️        | `N/A`   | Details about the request body                                                                                           |
 
@@ -199,12 +199,12 @@ This object contains list of all headers (used in [`request`](#request) and [`re
 
 ---
 
-### queryString
+### parameters
 
 This object contains list of all parameters & values parsed from a query string, if any (embedded in [`request`](#request) object).
 
 ```json
-"queryString": [
+"parameters": [
   { "name": "foo", "value": "bar" },
   { "name": "baz", "value": "hey" }
 ]
@@ -342,7 +342,7 @@ Summary of changes from `v1.1.0`:
         "method": "POST",
         "url": "https://mockbin.org/request",
         "httpVersion": "HTTP/1.1",
-        "queryString": [
+        "parameters": [
           { "name": "foo", "value": "bar" },
           { "name": "baz", "value": "hey" }
         ],


### PR DESCRIPTION
As the current queryString field is broken out into individual query parameter
key-value pairs, it is misleading to use queryString as the field name.

parameters, arguments, queryParameters, queryArguments would all better suit an
array field, instead of queryString.